### PR TITLE
fix paths, upper-case lower-case conflicts in linux

### DIFF
--- a/desktop/desktop.py
+++ b/desktop/desktop.py
@@ -29,7 +29,7 @@ class DesktopGUI:
 
 
     def icon_setup(self) -> None:
-        self.python_logo = ctk.CTkImage(Image.open("assets/desktop/python_logo.png"), size=(self.height/5, self.height/5))
+        self.python_logo = ctk.CTkImage(Image.open("Assets/desktop/python_logo.png"), size=(self.height/5, self.height/5))
 
     
     def create_gui(self) -> None:

--- a/desktop/file_widget.py
+++ b/desktop/file_widget.py
@@ -17,7 +17,7 @@ class TextFileWidget:
         file_body_frame.place(x=self.file.x_pos, y=self.file.y_pos)
         file_body_button = ctk.CTkButton(
             file_body_frame, width=75, height=100, command=self.on_click, text="",
-            image=ctk.CTkImage(Image.open("assets/desktop/python_logo.png"), size=(50, 50)), fg_color="transparent"
+            image=ctk.CTkImage(Image.open("Assets/desktop/python_logo.png"), size=(50, 50)), fg_color="transparent"
         ) # TODO: replace placeholder image
         file_body_button.place(anchor="center", relx=0.5, rely=0.5)
         file_body_name_label = ctk.CTkLabel(file_body_frame, width=75, height=20, text=self.file.name)

--- a/desktop/task_bar.py
+++ b/desktop/task_bar.py
@@ -21,12 +21,12 @@ class TaskBarGUI:
     
 
     def icon_setup(self) -> None:
-        self.python_icon = ctk.CTkImage(light_image=Image.open("assets/desktop/python_icon_dark.png"), dark_image=Image.open("assets/desktop/python_icon.png"), size=(40, 40))
-        self.snake_icon = ctk.CTkImage(light_image=Image.open("assets/desktop/snake_blue_icon.png"), dark_image=Image.open("assets/desktop/snake_yellow_icon.png"), size=(32, 32))
-        self.no_network_icon = ctk.CTkImage(light_image=Image.open("assets/desktop/no_internet_icon_dark.png"), dark_image=Image.open("assets/desktop/no_internet_icon.png"), size=(20, 20))
-        self.network_icon = ctk.CTkImage(light_image=Image.open("assets/desktop/wifi_icon_dark.png"), dark_image=Image.open("assets/desktop/wifi_icon.png"), size=(20, 20))
-        self.network_icon_off = ctk.CTkImage(light_image=Image.open("assets/desktop/wifi_icon.png"), dark_image=Image.open("assets/desktop/wifi_icon_dark.png"), size=(32, 32))
-        self.py_browse_icon = ctk.CTkImage(light_image=Image.open("assets/desktop/pybrowse_dark.png"), dark_image=Image.open("assets/desktop/pybrowse.png"), size=(32, 32))
+        self.python_icon = ctk.CTkImage(light_image=Image.open("Assets/desktop/python_icon_dark.png"), dark_image=Image.open("Assets/desktop/python_icon.png"), size=(40, 40))
+        self.snake_icon = ctk.CTkImage(light_image=Image.open("Assets/desktop/snake_blue_icon.png"), dark_image=Image.open("Assets/desktop/snake_yellow_icon.png"), size=(32, 32))
+        self.no_network_icon = ctk.CTkImage(light_image=Image.open("Assets/desktop/no_internet_icon_dark.png"), dark_image=Image.open("Assets/desktop/no_internet_icon.png"), size=(20, 20))
+        self.network_icon = ctk.CTkImage(light_image=Image.open("Assets/desktop/wifi_icon_dark.png"), dark_image=Image.open("Assets/desktop/wifi_icon.png"), size=(20, 20))
+        self.network_icon_off = ctk.CTkImage(light_image=Image.open("Assets/desktop/wifi_icon.png"), dark_image=Image.open("Assets/desktop/wifi_icon_dark.png"), size=(32, 32))
+        self.py_browse_icon = ctk.CTkImage(light_image=Image.open("Assets/desktop/pybrowse_dark.png"), dark_image=Image.open("Assets/desktop/pybrowse.png"), size=(32, 32))
 
     
     def create_taskbar(self) -> None:


### PR DESCRIPTION
Unlike Windows, In Linux, paths are case sensitive. so "assets" is different from "Assets" 

Also un-related but your web-browser isn't sorta working, 
<img width="1162" height="414" alt="image" src="https://github.com/user-attachments/assets/1eb57172-e8cf-43b5-946e-10e490a8b681" />
